### PR TITLE
revise in (struct hodo_inode, hodo_sub_lookup(..))

### DIFF
--- a/hodo.h
+++ b/hodo.h
@@ -44,6 +44,8 @@ struct hodo_inode {
     struct hodo_block_pos single_indirect;
     struct hodo_block_pos double_indirect;
     struct hodo_block_pos triple_indirect;
+
+    char padding[192];
 };
 
 struct hodo_datablock {


### PR DESCRIPTION
1.struct hodo_inode가 512B 크기가 되도록 패딩 추가

2.가리키는 데이터 블럭 위치가 (0,0)이면 읽어오지 않도록 해서, 아이노드가 가리키는 직간접적인 데이터블록들을 모두 읽는 기존의 비효율적인 방식을 find_inode_num(..)에서의 방식을 개선

3.lookup에서 찾고자 하는 이름의 아이노드를 저장장치에서 못 찾으면 d_add(dentry, NULL);로 vfs에게 그런 이름의 아이노드는 없다고 통보하도록 함.