### PR TITLE
hodo_dentry- > hodo_dirent 변경 및 readdir(..) 초안

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# HDMR File System
-순차적 쓰기만이 가능한 저장장치인 ZBD(Zoned Block Device)의 각 존을 사용자가 읽고 쓸 수 있도록 한 Western Digital Corporation의 'zonefs' 파일시스템을 기반으로 하여, 이를 POSIX와 호환되도록 확장 구현한 HDMR 파일 시스템의 리포지토리입니다.
+# HODO File System
+순차적 쓰기만이 가능한 저장장치인 ZBD(Zoned Block Device)의 각 존을 사용자가 읽고 쓸 수 있도록 한 Western Digital Corporation의 'zonefs' 파일시스템을 기반으로 하여, 이를 POSIX와 호환되도록 확장 구현한 HODO 파일 시스템의 리포지토리입니다.

--- a/hodo.h
+++ b/hodo.h
@@ -15,6 +15,9 @@
 #define HODO_MAX_NAME_LEN   16
 #define HODO_MAX_INODE      (1 << 16)
 
+#define HODO_TYPE_DIR       1
+#define HODO_TYPE_REG       2            
+
 #define ZONEFS_TRACE() pr_info("zonefs: >>> %s called\n", __func__)
 
 struct hodo_block_pos {
@@ -62,9 +65,11 @@ struct hodo_mapping_info {
 
 extern struct hodo_mapping_info mapping_info;
 
-struct hodo_dentry {
+struct hodo_dirent {
     char name[HODO_MAX_NAME_LEN];
+    uint8_t name_len;
     uint64_t i_ino;
+    uint8_t file_type;
 };
 
 // prototype: hodo filesystem initialization


### PR DESCRIPTION
1.기존의 hodo_dentry 구조체 이름 및 멤버 변수 구성 변경
-리눅스의 온메모리 vfs dentry와, 파일시스템의 저장장치에 기록되는 디렉토리 엔트리를 구분하기 위해, 후자는 hodo_dirent로 명명. -readdir등의 과정에서 파일이 일반 파일인지, 디렉토리 파일인지를 굳이 저장장치로부터 해당 파일의 아이노드를 읽어오지 않고 바로 알 수 있도록 디렉토리 엔트리(hodo_dirent)에 멤버 변수 추가.

struct hodo_dirent {			//name changed
    char name[HODO_MAX_NAME_LEN];
    uint8_t name_len;			//added
    uint64_t i_ino;			//added
    uint8_t file_type;			//added
};

2.readdir(..) 초안 작성
-빌드는 가능하나 기능은 미완성
-기존 zonefs의 seq, cnv 디렉토리를 숨기고, 오직 저장장치에 직접 아이노드와 데이터블럭이 기록되는 사용자 파일들만 읽도록 할 것 -구현은 lookup(..)에서의 find_inode_number(..)함수와 그 하위 함수를 복사 및 변경해서 구현 중 -> 반복사용되는 중요 로직이므로 추후에 함수 포인터 등으로 리팩터링할 예정

3.find_inode_number_from_indirect_datablock(..)에서, 가리키는 주소가 (0,0)인 경우에 읽지 않도록 하는 로직이 다른 함수들과 달리 작성되어있지 않아 추가함

4.README에서 본 파일시스템의 이름을 HDMR -> HODO로 변경